### PR TITLE
chore: remove as attr from Link

### DIFF
--- a/components/__snapshots__/nav.spec.tsx.snap
+++ b/components/__snapshots__/nav.spec.tsx.snap
@@ -104,8 +104,7 @@ exports[`nav snapshots render with categories 1`] = `
           key="category-1"
         >
           <Link
-            as="/category/category-1"
-            href="/category/[id]"
+            href="/category/category-1"
           >
             <a
               className="nav-link"
@@ -120,8 +119,7 @@ exports[`nav snapshots render with categories 1`] = `
           key="category-2"
         >
           <Link
-            as="/category/category-2"
-            href="/category/[id]"
+            href="/category/category-2"
           >
             <a
               className="nav-link"

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -32,7 +32,7 @@ export const Nav = ({ categories }: Props) => (
             categories.map((category: Category) => {
               return (
                 <li key={category.slug} className="nav-item">
-                  <Link href="/category/[id]" as={`/category/${category.slug}`}>
+                  <Link href={`/category/${category.slug}`}>
                     <a href={`/category/${category.slug}`} className="nav-link">
                       {category.name}
                     </a>

--- a/pages/category/[id].tsx
+++ b/pages/category/[id].tsx
@@ -35,7 +35,7 @@ const Category = ({ posts, category }: Props) => {
                 ></div>
                 <div className="card-body px-0 pb-0 d-flex flex-column align-items-start">
                   <h2 className="h2 font-weight-bold">
-                    <Link href="/post/[id]" as={`/post/${first.slug}`}>
+                    <Link href={`/post/${first.slug}`}>
                       <a href={`/post/${first.slug}`} className="text-dark">
                         {first.title}
                       </a>
@@ -61,7 +61,7 @@ const Category = ({ posts, category }: Props) => {
                 <div key={post.slug} className="mb-3 d-flex justify-content-between">
                   <div className="pr-3">
                     <h2 className="mb-1 h4 font-weight-bold">
-                      <Link href="/post/[id]">
+                      <Link href={`/post/${post.slug}`}>
                         <a href={`/post/${post.slug}`} className="text-dark">
                           {post.title}
                         </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,7 +23,7 @@ const Home = ({ posts }: { posts: Post[] }) => {
                 <div className="col-md-6 pt-6 pb-6 align-self-center">
                   <h1 className="secondfont mb-3 font-weight-bold">{first.title}</h1>
                   <ReactMarkdown source={first.shortBody} className="mb-3" />
-                  <Link href="/post/[id]" as={`/post/${first.slug}`}>
+                  <Link href={`/post/${first.slug}`}>
                     <a href={`/post/${first.slug}`} className="btn btn-dark">
                       Read More
                     </a>
@@ -54,7 +54,7 @@ const Home = ({ posts }: { posts: Post[] }) => {
                 <div key={post.slug} className="mb-3 d-flex justify-content-between">
                   <div className="pr-3">
                     <h2 className="mb-1 h4 font-weight-bold">
-                      <Link href="/post/[id]" as={`/post/${post.slug}`}>
+                      <Link href={`/post/${post.slug}`}>
                         <a href={`/post/${post.slug}`} className="text-dark">
                           {post.title}
                         </a>

--- a/pages/post/[id].tsx
+++ b/pages/post/[id].tsx
@@ -34,7 +34,7 @@ const Post = ({ post }: { post: PostModel }) => {
             <div className="row justify-content-between">
               <div className="col-md-6 pt-6 pb-6 pr-6 align-self-center">
                 <p className="text-uppercase font-weight-bold">
-                  <Link href="/category/[id]" as={`/category/${post.category.slug}`}>
+                  <Link href={`/category/${post.category.slug}`}>
                     <a href={`/category/${post.category.slug}`} className="text-danger">
                       {post.category.name}
                     </a>


### PR DESCRIPTION
With the latest Next.js version `as` attribute is not longer required.